### PR TITLE
Avoid SlickException while changing password

### DIFF
--- a/app/models/daos/PasswordInfoDAO.scala
+++ b/app/models/daos/PasswordInfoDAO.scala
@@ -59,8 +59,12 @@ class PasswordInfoDAO @Inject() (
       dbLoginInfoOption.map {
         dbLoginInfo =>
           {
-            val dbPasswordInfo = DbPasswordInfo(authInfo.hasher, authInfo.password, authInfo.salt, dbLoginInfo.id.get)
-            db.run(passwordInfoQuery(loginInfo).update(dbPasswordInfo).transactionally)
+            db.run { 
+              passwordInfos.filter(_.loginInfoId === dbLoginInfo.id) 
+              .map(p => (p.hasher, p.password, p.salt)) 
+              .update((authInfo.hasher, authInfo.password, authInfo.salt)) 
+              .transactionally 
+            }
           }
       }
     }).map { _ =>


### PR DESCRIPTION
Slick cannot do select and update inside one request. And we don't need it. We need just to update passwordInfo with information that we already have.